### PR TITLE
[15.0] Generalize auto printing and remove dependencies to 3rd party modules

### DIFF
--- a/carrier_shipping_label_template/__manifest__.py
+++ b/carrier_shipping_label_template/__manifest__.py
@@ -2,11 +2,12 @@
     "name": "Carrier shipping label template",
     "summary": "Print shipping label from print menu",
     "version": "15.0.3.1.5",
-    "depends": [
-        "ups_delivery_carrier",
-        "delivery_deutsche_post",
+    "data": [
+        "data/report_shipping_label.xml",
     ],
-    "data": ["views/report_shipping_label.xml"],
+    "depends": [
+        "delivery",
+    ],
     "auto_install": False,
     "installable": True,
     "author": "Nitrokey GmbH",

--- a/carrier_shipping_label_template/data/report_shipping_label.xml
+++ b/carrier_shipping_label_template/data/report_shipping_label.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="report_qweb_paperformat_ups" model="report.paperformat">
+    <record id="report_qweb_paperformat" model="report.paperformat">
         <field name="name">100 x 150 mm thermal label (e.g. Zebra GK420D)</field>
         <field name="default" eval="True" />
         <field name="format">custom</field>
@@ -20,35 +20,18 @@
         <field name="name">Shipping Label</field>
         <field name="model">stock.picking</field>
         <field name="report_type">qweb-pdf</field>
-        <field
-            name="report_name"
-        >carrier_shipping_label_template.report_shipping_label</field>
-        <field
-            name="report_file"
-        >carrier_shipping_label_template.report_shipping_label</field>
-        <field
-            name="report_name"
-        >carrier_shipping_label_template.report_shipping_label</field>
-            <field
-            name="report_file"
-        >carrier_shipping_label_template.report_shipping_label</field>
+        <field name="report_name">carrier_shipping_label_template.dummy_report</field>
+        <field name="report_file">carrier_shipping_label_template.dummy_report</field>
         <field name="binding_type">report</field>
         <field
             name="paperformat_id"
-            ref="carrier_shipping_label_template.report_qweb_paperformat_ups"
+            ref="carrier_shipping_label_template.report_qweb_paperformat"
         />
     </record>
 
-    <template id="report_shipping_label">
+    <!-- -->
+    <template id="dummy_report">
         <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="o">
-                <div style="overflow:hidden;weight:800px;">
-                    <img
-                        t-attf-src="data:image/*;base64,{{o.ups_image}}"
-                        style="-webkit-transform:rotate(90deg);overflow:hidden;margin-top:160px;width:720px;margin-left:-143;margin-bottom:60px;"
-                    />
-                </div>
-            </t>
         </t>
     </template>
 </odoo>

--- a/carrier_shipping_label_template/models/__init__.py
+++ b/carrier_shipping_label_template/models/__init__.py
@@ -1,1 +1,1 @@
-from . import delivery_carrier, report
+from . import delivery_carrier, report, stock_picking

--- a/carrier_shipping_label_template/models/delivery_carrier.py
+++ b/carrier_shipping_label_template/models/delivery_carrier.py
@@ -1,23 +1,30 @@
-import base64
+from collections import defaultdict
 
-from odoo import fields, models
+from odoo import models
 
 
-class UPSReturnDeliveryCarrier(models.Model):
+class DeliveryCarrier(models.Model):
     _inherit = "delivery.carrier"
 
-    def ups_send_shipping(self, pickings):
-        res = super().ups_send_shipping(pickings)
-        if res[0].get("attachments"):
-            picking_vals = {
-                "ups_image": base64.b64encode(res[0].get("attachments")[0][1])
-            }
-            pickings.write(picking_vals)
+    def filter_shipping_labels(self, attachments):
+        """Filtering function to get only the labels. Naming etc. depends on the
+        delivery module which is why the hook exists"""
+        return attachments
+
+    def send_shipping(self, pickings):
+        domain = [("res_model", "=", pickings._name), ("res_id", "in", pickings.ids)]
+        labels = self.env["ir.attachment"].search(domain)
+        res = super().send_shipping(pickings)
+
+        # All attachments that are generated during send_shipping call should be
+        # shipping labels
+        attachments = defaultdict(labels.browse)
+        for label in (labels.search(domain) - labels).exists():
+            attachments[label.res_id] |= label
+
+        for pick in pickings:
+            labels = attachments.get(pick.id)
+            label_ids = self.filter_shipping_labels(labels).ids if labels else []
+            pick.shipping_label_ids = [(6, 0, label_ids)]
 
         return res
-
-
-class StockPicking(models.Model):
-    _inherit = "stock.picking"
-
-    ups_image = fields.Binary(string="UPS Image")

--- a/carrier_shipping_label_template/models/report.py
+++ b/carrier_shipping_label_template/models/report.py
@@ -1,62 +1,36 @@
 import base64
 import io
 
-from odoo import api, models
+from odoo import _, models
+from odoo.exceptions import UserError
 
 
 class IrActionsReportReportlab(models.Model):
     _inherit = "ir.actions.report"
 
-    def _render_qweb_pdf(self, res_ids=None, data=None):
-        if self.report_name in [
-            "carrier_shipping_label_template.report_shipping_label"
-        ]:
-            self = self.with_context(shipping_label_res_ids=res_ids)
-        return super()._render_qweb_pdf(res_ids, data)
-
-    @api.model
-    def _render_qweb_html(self, docids, data=None):
-        """This method generates and returns html version of a report."""
-        if (
-            self.report_name
-            not in ["carrier_shipping_label_template.report_shipping_label"]
-        ) or not docids:
-            return super()._render_qweb_html(docids, data)
-        new_doc_ids = (
-            self.env["stock.picking"]
-            .search([("id", "in", docids), ("label_de_attach_id", "=", False)])
-            .ids
+    def is_shipping_label_report(self):
+        return (
+            self.xml_id
+            == "carrier_shipping_label_template.action_report_shipping_label"
         )
-        return super()._render_qweb_html(new_doc_ids, data)
 
-    def _post_pdf(self, save_in_attachment, pdf_content=None, res_ids=None):
-        if self.report_name not in [
-            "carrier_shipping_label_template.report_shipping_label"
-        ]:
-            return super()._post_pdf(save_in_attachment, pdf_content, res_ids)
+    def _render_qweb_pdf(self, res_ids=None, data=None):
+        if not self.is_shipping_label_report():
+            return super()._render_qweb_pdf(res_ids, data)
 
-        shipping_label_res_ids = self._context.get("shipping_label_res_ids")
-        if shipping_label_res_ids:
-            Model = self.env[self.model]
-            records = Model.browse(shipping_label_res_ids)
-            wk_record_ids = Model
-            for record in records:
-                attachment = record.label_de_attach_id
-                if attachment:
-                    save_in_attachment[record.id] = io.BytesIO(
-                        base64.decodebytes(attachment.datas)
-                    )
-                else:
-                    wk_record_ids += record
-            res_ids = wk_record_ids.ids
-            if not res_ids:
-                pdf_content = None
+        if self.model != "stock.picking":
+            raise UserError(_("Shipping Label Report is not defined on pickings"))
 
-        return super()._post_pdf(save_in_attachment, pdf_content, res_ids)
+        pickings = self.env["stock.picking"].browse(res_ids)
+        labels = pickings.mapped("shipping_label_ids")
+        if not labels:
+            raise UserError(_("No shipping labels to print"))
+
+        streams = [io.BytesIO(base64.decodebytes(att.datas)) for att in labels]
+        return self._merge_pdfs(streams), "pdf"
 
     def _retrieve_attachment(self, record):
-        if self.report_name in [
-            "carrier_shipping_label_template.report_shipping_label"
-        ]:
+        if self.is_shipping_label_report():
             return None
+
         return super()._retrieve_attachment(record)

--- a/carrier_shipping_label_template/models/stock_picking.py
+++ b/carrier_shipping_label_template/models/stock_picking.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    shipping_label_ids = fields.Many2many("ir.attachment", string="Labels")

--- a/delivery_automatic_print/__manifest__.py
+++ b/delivery_automatic_print/__manifest__.py
@@ -2,7 +2,11 @@
     "name": "Delivery Automatic Print",
     "summary": "Print shipping label automatically",
     "version": "15.0.1.0.0",
-    "depends": ["carrier_shipping_label_template", "stock"],
+    "depends": [
+        "base_report_to_printer",
+        "carrier_shipping_label_template",
+        "stock",
+    ],
     "data": [],
     "auto_install": False,
     "installable": True,

--- a/delivery_automatic_print/models/report_print.py
+++ b/delivery_automatic_print/models/report_print.py
@@ -4,20 +4,24 @@ from odoo import models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    def reports_to_print(self):
+        reports = self.env["ir.actions.report"]
+        for ref in [
+            "carrier_shipping_label_template.action_report_shipping_label",
+            "stock.action_report_picking",
+            "stock.action_report_delivery",
+        ]:
+            report = self.env.ref(ref, False)
+            if report and report.printing_printer_id:
+                reports |= report
+        return reports
+
     def button_validate(self):
         res = super().button_validate()
-        for pickings in self:
-            if pickings.picking_type_id.code == "outgoing":
-                if pickings.ups_image or pickings.label_de_attach_id:
-                    self.env.ref(
-                        "carrier_shipping_label_template.action_report_shipping_label"
-                    ).sudo()._render_qweb_pdf([self.id])[0]
+        if self.env.context.get("must_skip_send_to_printer"):
+            return res
 
-                self.env.ref("stock.action_report_picking").sudo()._render_qweb_pdf(
-                    [self.id]
-                )[0]
-                self.env.ref("stock.action_report_delivery").sudo()._render_qweb_pdf(
-                    [self.id]
-                )[0]
+        for report in self.reports_to_print():
+            report.sudo()._render_qweb_pdf(self.ids)
 
         return res


### PR DESCRIPTION
This PR removes the dependencies of the automatic label printing to 3rd party modules. Labels are gathered by observing the `send_shipping` before and after the call of the delivery method.