### PR TITLE
Re-added needaction_partner_id field to bitcoin notification

### DIFF
--- a/payment_bitcoin/i18n/de.po
+++ b/payment_bitcoin/i18n/de.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-06 15:23+0000\n"
-"PO-Revision-Date: 2023-04-06 15:23+0000\n"
+"POT-Creation-Date: 2025-02-24 12:15+0000\n"
+"PO-Revision-Date: 2025-02-24 12:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +18,19 @@ msgstr ""
 #. module: payment_bitcoin
 #: model_terms:ir.ui.view,arch_db:payment_bitcoin.transaction_form_bitcoin
 msgid "&amp;nbsp;"
+msgstr ""
+
+#. module: payment_bitcoin
+#: code:addons/payment_bitcoin/controllers/main.py:0
+#, python-format
+msgid ""
+"<div class=\"panel-body\" style=\"padding-bottom:0px;\">\n"
+"                                <h4><strong>%(info)s</strong></h4>\n"
+"                            </div>\n"
+"                            <div class=\"panel-body d-flex justify-content-center                             align-items-center\" 'style=\"padding-top:5px;                             padding-bottom:0px;\">\n"
+"                            <div><img class=\"bitcoin_barcode\" src=                            \"/report/barcode/bitcoin/?br_type=QR&amp;value=%(uri)s\n"
+"                            &amp;width=300&amp;height=300\"                            ></div>\n"
+"                            </div>"
 msgstr ""
 
 #. module: payment_bitcoin
@@ -49,19 +62,6 @@ msgstr ""
 "                          </div>"
 
 #. module: payment_bitcoin
-#: code:addons/payment_bitcoin/controllers/main.py:0
-#, python-format
-msgid ""
-"<div class=\"panel-body\" style=\"padding-bottom:0px;\">\n"
-"                                <h4><strong>%(info)s</strong></h4>\n"
-"                            </div>\n"
-"                            <div class=\"panel-body d-flex justify-content-center                             align-items-center\" 'style=\"padding-top:5px;                             padding-bottom:0px;\">\n"
-"                            <div><img class=\"bitcoin_barcode\" src=                            \"/report/barcode/bitcoin/?br_type=QR&amp;value=%(uri)s\n"
-"                            &amp;width=300&amp;height=300\"                            ></div>\n"
-"                            </div>"
-msgstr ""
-
-#. module: payment_bitcoin
 #: model:mail.template,body_html:payment_bitcoin.mail_template_data_bit_coin_order_notification
 msgid ""
 "<div style=\"margin: 0px; padding: 0px;\">\n"
@@ -85,13 +85,15 @@ msgstr ""
 "        "
 
 #. module: payment_bitcoin
-#: model_terms:ir.ui.view,arch_db:payment_bitcoin.view_account_config_min_unused_bitcoin
+#: model_terms:ir.ui.view,arch_db:payment_bitcoin.payment_bitcoin_acquirer_form
 msgid ""
-"<span class=\"o_form_label\">Hours</span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" aria-label=\"Address check for orders which are not older than\" role=\"img\"/>"
+"<span>\n"
+"                        <strong>In Hours</strong>\n"
+"                    </span>"
 msgstr ""
-"<span class=\"o_form_label\">Stunden</span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" aria-label=\"Adressprüfung für Aufträge, die nicht älter sind als\" role=\"img\"/>"
+"<span>\n"
+"                        <strong>In Stunden</strong>\n"
+"                    </span>"
 
 #. module: payment_bitcoin
 #: model_terms:ir.ui.view,arch_db:payment_bitcoin.payment_bitcoin_acquirer_form
@@ -105,10 +107,36 @@ msgstr ""
 "                    </span>"
 
 #. module: payment_bitcoin
+#: model_terms:payment.acquirer,cancel_msg:payment_bitcoin.payment_acquirer_bitcoin
+msgid "<span><i>Abbruch,</i> Ihre Bezahlung wurde abgebrochen.</span>"
+msgstr ""
+
+#. module: payment_bitcoin
+#: model_terms:payment.acquirer,pending_msg:payment_bitcoin.payment_acquirer_bitcoin
+msgid ""
+"<span><i>Ausstehend,</i> Ihre Onlinezahlung wurde erfolgreich verarbeitet. "
+"Aber Ihre Bestellung wurde noch nicht bestätigt.</span>"
+msgstr ""
+
+#. module: payment_bitcoin
+#: model_terms:payment.acquirer,done_msg:payment_bitcoin.payment_acquirer_bitcoin
+msgid ""
+"<span><i>Erledigt,</i> Ihre Onlinezahlung wurde erfolgreich verarbeitet. "
+"Vielen Dank für Ihre Bestellung</span>"
+msgstr ""
+
+#. module: payment_bitcoin
+#: model_terms:ir.ui.view,arch_db:payment_bitcoin.transaction_status_payment_bitcoin
+msgid "<strong>Pay Within:</strong>"
+msgstr "<strong>Zu zahlen innerhalb:</strong>"
+
+#. module: payment_bitcoin
 #: model:ir.model.fields,help:payment_bitcoin.field_payment_acquirer__deadline
 msgid ""
 "Add a deadline to Bitcoin payments within which the payment should be made."
-msgstr "Fügen Sie Bitcoin-Zahlungen eine Frist hinzu, innerhalb derer die Zahlung erfolgen soll."
+msgstr ""
+"Fügen Sie Bitcoin-Zahlungen eine Frist hinzu, innerhalb derer die Zahlung "
+"erfolgen soll."
 
 #. module: payment_bitcoin
 #: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__name
@@ -121,16 +149,9 @@ msgid "Address Link"
 msgstr "Adresslink"
 
 #. module: payment_bitcoin
-#: model_terms:ir.ui.view,arch_db:payment_bitcoin.view_account_config_min_unused_bitcoin
-msgid "Addresses check for orders which are not older than"
-msgstr "Adressprüfung für Aufträge, die nicht älter sind als"
-
-#. module: payment_bitcoin
-#: model:ir.model.fields,help:payment_bitcoin.field_res_config_settings__bitcoin_order_older_than
-#: model:ir.model.fields,help:payment_bitcoin.field_webkul_website_addons__bitcoin_order_older_than
-#: model:ir.model.fields,help:payment_bitcoin.field_website_country_config__bitcoin_order_older_than
+#: model:ir.model.fields,help:payment_bitcoin.field_payment_acquirer__bitcoin_order_older_than
 msgid "Address check for orders which are not older than"
-msgstr "Adressprüfung für Aufträge, die nicht älter sind als"
+msgstr ""
 
 #. module: payment_bitcoin
 #: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__amount
@@ -195,11 +216,6 @@ msgid "Bitcoin Addresses"
 msgstr "Bitcoin Adressen"
 
 #. module: payment_bitcoin
-#: model_terms:ir.ui.view,arch_db:payment_bitcoin.view_account_config_min_unused_bitcoin
-msgid "Bitcoin Addresses check"
-msgstr "Bitcoin Adressprüfung"
-
-#. module: payment_bitcoin
 #: model:ir.model.fields,field_description:payment_bitcoin.field_payment_transaction__bitcoin_amount
 msgid "Bitcoin Amount"
 msgstr "Bitcoin-Betrag"
@@ -223,28 +239,36 @@ msgid "Bitcoin Rate URL"
 msgstr "Bitcoin-Rate URL"
 
 #. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_payment_acquirer__bitcoin_send_email
+msgid "Bitcoin Send Email"
+msgstr ""
+
+#. module: payment_bitcoin
 #: code:addons/payment_bitcoin/models/bitcoin.py:0
 #, python-format
-msgid ""
-"Bitcoin transaction %(transaction)s"
-"                                             for %(address)s"
-"                                             with %(amount)s BTC has"
-"                                         been confirmed. This is  "
-"%(max_amount_received)s                                         BTC too "
-"much. The                                         corresponding payment is "
-"posted: %(invoices)s"
-msgstr "Die Bitcoin-Transaktion %(transaction)s für %(address)s mit %(amount)s BTC wurde bestätigt. Dies sind  %(max_amount_received)s BTC zu viel. Die entsprechende Zahlung wird gebucht: %(invoices)s"
+msgid "Bitcoin addresses running low"
+msgstr "Bitcoin-Adressen laufen aus"
 
 #. module: payment_bitcoin
 #: code:addons/payment_bitcoin/models/bitcoin.py:0
 #, python-format
 msgid ""
-"Bitcoin transaction %(transaction)s for"
-"                                             %(address)s with %(amount)s BTC"
-" has been                                             confirmed. The "
-"corresponding payment is                                              "
-"posted: %(invoices)s"
-msgstr "Die Bitcoin-Transaktion %(transaction)s für %(address)s mit %(amount)s BTC wurde bestätigt. Die entsprechende Zahlung wird gebucht: %(invoices)s"
+"Bitcoin transaction %(transaction)s                                 for "
+"%(address)s                                 with %(amount)s BTC has"
+"                             been confirmed. This is  "
+"%(max_amount_received)s                             BTC too much. The"
+"                             corresponding payment is posted: %(invoices)s"
+msgstr ""
+
+#. module: payment_bitcoin
+#: code:addons/payment_bitcoin/models/bitcoin.py:0
+#, python-format
+msgid ""
+"Bitcoin transaction %(transaction)s for                                     "
+"%(address)s with %(amount)s BTC has been"
+"                                     confirmed. The corresponding payment is"
+"                                      posted: %(invoices)s"
+msgstr ""
 
 #. module: payment_bitcoin
 #: code:addons/payment_bitcoin/models/bitcoin.py:0
@@ -254,13 +278,15 @@ msgid ""
 "%(address)s with %(amount)s                                 BTC has been "
 "confirmed. It is missing                                 "
 "%(insufficiant_amount)s BTC."
-msgstr "Die Bitcoin-Transaktion %(transaction)s für %(address)s mit %(amount)s BTC wurde bestätigt. Es fehlen %(insufficiant_amount)s BTC."
+msgstr ""
+"Die Bitcoin-Transaktion %(transaction)s für %(address)s mit %(amount)s BTC "
+"wurde bestätigt. Es fehlen %(insufficiant_amount)s BTC."
 
 #. module: payment_bitcoin
 #: model:ir.actions.server,name:payment_bitcoin.ir_cron_bitcoin_payment_reconciliation_ir_actions_server
 #: model:ir.cron,cron_name:payment_bitcoin.ir_cron_bitcoin_payment_reconciliation
 #: model:ir.cron,name:payment_bitcoin.ir_cron_bitcoin_payment_reconciliation
-msgid "Bitcoin: Addresses Check"
+msgid "Bitcoin: Addresses Checking (defused) (defused) (defused)"
 msgstr "Bitcoin Adressprüfung"
 
 #. module: payment_bitcoin
@@ -330,6 +356,110 @@ msgstr "Anzeigename"
 msgid "Display Unit"
 msgstr "Bildschirm"
 
+#. module: payment_bitcoin
+#: model:mail.template,subject:payment_bitcoin.mail_template_data_bit_coin_order_notification
+msgid "Don't Validate Order {{object.name}}"
+msgstr "payment for order {{object.name}}"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_payment_acquirer__bitcoin_order_older_than
+msgid "Hours"
+msgstr "Stunden"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__id
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate__id
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__id
+msgid "ID"
+msgstr "ICH WÜRDE"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,help:payment_bitcoin.field_res_config_settings__min_unused_bitcoin
+msgid ""
+"If amount of unused Bitcoin addresses goes below this, than system sends "
+"notifications to its related users."
+msgstr ""
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__invoice_id
+msgid "Invoice Assigned"
+msgstr ""
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__invoice_id
+msgid "Invoice ID"
+msgstr ""
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__is_btc_used
+msgid "Is Bitcoin used?"
+msgstr ""
+
+#. module: payment_bitcoin
+#: model:ir.model,name:payment_bitcoin.model_account_move
+msgid "Journal Entry"
+msgstr "Buchungssatz"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address____last_update
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate____last_update
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line____last_update
+msgid "Last Modified on"
+msgstr "Zuletzt geändert am"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__write_uid
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate__write_uid
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__write_uid
+msgid "Last Updated by"
+msgstr "Zuletzt aktualisiert durch"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__write_date
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate__write_date
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__write_date
+msgid "Last Updated on"
+msgstr "Zuletzt aktualisiert am"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate__markup
+msgid "Markup (%)"
+msgstr "Aufschlag (%)"
+
+#. module: payment_bitcoin
+#: model_terms:ir.ui.view,arch_db:payment_bitcoin.view_account_config_min_unused_bitcoin
+msgid "Minimum Unused Bitcoin Addresses"
+msgstr "Minimale Anzahl verwendeter Bitcoin-Adressen"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_res_config_settings__min_unused_bitcoin
+msgid "Minimun Unused Bitcoin"
+msgstr "Minimale Anzahl verwendeter Bitcoin"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_address__order_id
+msgid "Order Assigned"
+msgstr "Auftrag zugewiesen"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__order_id
+msgid "Order ID"
+msgstr "Auftragsnummer"
+
+#. module: payment_bitcoin
+#: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate_line__name
+msgid "Origin"
+msgstr "Ursprung"
+
+#. module: payment_bitcoin
+#: model:ir.model,name:payment_bitcoin.model_payment_acquirer
+msgid "Payment Acquirer"
+msgstr "Zahlungsanbieter"
+
+#. module: payment_bitcoin
+#: model:ir.model,name:payment_bitcoin.model_account_payment_method
+msgid "Payment Methods"
+msgstr "Zahlungsmethoden"
 
 #. module: payment_bitcoin
 #: model:ir.model,name:payment_bitcoin.model_payment_transaction
@@ -350,12 +480,20 @@ msgid "Payment method Bitcoin is currently unavailable."
 msgstr "Die Zahlungsmethode Bitcoin ist derzeit nicht verfügbar"
 
 #. module: payment_bitcoin
+#: code:addons/payment_bitcoin/models/bitcoin.py:0
+#, python-format
+msgid "Payment reference required"
+msgstr "Zahlungsreferenz erforderlich"
+
+#. module: payment_bitcoin
 #: code:addons/payment_bitcoin/controllers/main.py:0
 #, python-format
 msgid ""
 "Please send %(amount_btc)s %(unit_btc)s (%(amount_mbtc)s %(unit_mbtc)s)"
 "             to the address %(address)s by %(deadline_date)s UTC."
-msgstr "Bitte senden Sie den Betrag von %(amount_btc)s %(unit_btc)s (%(amount_mbtc)s %(unit_mbtc)s) bis um %(deadline_date)s UTC an die Adresse %(address)s"
+msgstr ""
+"Bitte senden Sie den Betrag von %(amount_btc)s %(unit_btc)s (%(amount_mbtc)s"
+" %(unit_mbtc)s) bis um %(deadline_date)s UTC an die Adresse %(address)s"
 
 #. module: payment_bitcoin
 #: model:ir.model.fields,field_description:payment_bitcoin.field_payment_acquirer__provider
@@ -373,15 +511,14 @@ msgid "Rates"
 msgstr "Kurse"
 
 #. module: payment_bitcoin
+#: model:ir.model,name:payment_bitcoin.model_account_payment_register
+msgid "Register Payment"
+msgstr "Zahlung registrieren"
+
+#. module: payment_bitcoin
 #: model:ir.model.fields,field_description:payment_bitcoin.field_bitcoin_rate__digits
 msgid "Round to Digits"
 msgstr "Auf Ziffern runden"
-
-#. module: payment_bitcoin
-#: code:addons/payment_bitcoin/models/bitcoin.py:0
-#, python-format
-msgid "Payment reference required"
-msgstr "Zahlungsreferenz erforderlich"
 
 #. module: payment_bitcoin
 #: model_terms:ir.ui.view,arch_db:payment_bitcoin.view_account_config_min_unused_bitcoin
@@ -401,9 +538,17 @@ msgid "The Payment Service Provider to use with this acquirer"
 msgstr "Der mit diesem Zahlungsanbieter zu verwendende Dienstleister"
 
 #. module: payment_bitcoin
+#: code:addons/payment_bitcoin/controllers/main.py:0
+#, python-format
+msgid "The access token is invalid."
+msgstr ""
+
+#. module: payment_bitcoin
 #: model_terms:payment.acquirer,pre_msg:payment_bitcoin.payment_acquirer_bitcoin
 msgid "Transfer information will be provided after choosing the payment mode."
-msgstr "Die Überweisungsinformationen werden nach Auswahl des Zahlungsmodus zur Verfügung gestellt."
+msgstr ""
+"Die Überweisungsinformationen werden nach Auswahl des Zahlungsmodus zur "
+"Verfügung gestellt."
 
 #. module: payment_bitcoin
 #: model_terms:ir.ui.view,arch_db:payment_bitcoin.view_bitcoin_address_search
@@ -416,25 +561,10 @@ msgid "Your payment has been authorized."
 msgstr ""
 
 #. module: payment_bitcoin
-#: model_terms:payment.acquirer,cancel_msg:payment_bitcoin.payment_acquirer_bitcoin
-msgid "Your payment has been cancelled."
-msgstr ""
-
-#. module: payment_bitcoin
-#: model_terms:payment.acquirer,pending_msg:payment_bitcoin.payment_acquirer_bitcoin
-msgid ""
-"Your payment has been successfully processed but is waiting for approval."
-msgstr ""
-
-#. module: payment_bitcoin
-#: model_terms:payment.acquirer,done_msg:payment_bitcoin.payment_acquirer_bitcoin
-msgid "Your payment has been successfully processed. Thank you!"
-msgstr ""
-
-#. module: payment_bitcoin
 #: model:ir.model.fields,help:payment_bitcoin.field_bitcoin_rate__valid_minutes
 msgid "after this minutes rate will be checked again for same amount"
-msgstr "Nach dieser Zeit wird der Kurs erneut auf den gleichen Betrag überprüft"
+msgstr ""
+"Nach dieser Zeit wird der Kurs erneut auf den gleichen Betrag überprüft"
 
 #. module: payment_bitcoin
 #: code:addons/payment_bitcoin/controllers/main.py:0

--- a/payment_bitcoin/models/bitcoin.py
+++ b/payment_bitcoin/models/bitcoin.py
@@ -389,6 +389,10 @@ class BitcoinAddress(models.Model):
             if group:
                 groups += group
 
+            needaction_partner_ids = [
+                (4, user.partner_id.id) for user in groups.mapped("users")
+            ]
+
             self.env["mail.message"].create(
                 {
                     "message_type": "notification",
@@ -396,6 +400,8 @@ class BitcoinAddress(models.Model):
                     "date": datetime.now(),
                     "body": "<p>Only %s unused Bitcoin addresses are left. "
                     "Please add new addresses.</p>" % unused_address_count,
+                    "partner_ids": needaction_partner_ids,
+                    "needaction": True,
                 }
             )
         return

--- a/payment_bitcoin/models/bitcoin.py
+++ b/payment_bitcoin/models/bitcoin.py
@@ -1,11 +1,10 @@
 import codecs
 import logging
-from datetime import datetime, timedelta as td
+from datetime import date, datetime, timedelta as td
 from hashlib import sha256
 
 import requests
 from dateutil.relativedelta import relativedelta
-from datetime import date
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError

--- a/payment_bitcoin/models/bitcoin.py
+++ b/payment_bitcoin/models/bitcoin.py
@@ -5,6 +5,7 @@ from hashlib import sha256
 
 import requests
 from dateutil.relativedelta import relativedelta
+from datetime import date
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -389,21 +390,14 @@ class BitcoinAddress(models.Model):
             if group:
                 groups += group
 
-            needaction_partner_ids = [
-                (4, user.partner_id.id) for user in groups.mapped("users")
-            ]
+            for user in groups.mapped("users"):
+                user.partner_id.activity_schedule(
+                    "mail.mail_activity_data_todo",
+                    summary=_("Bitcoin addresses running low"),
+                    user_id=user.id,
+                    date_deadline=date.today(),
+                )
 
-            self.env["mail.message"].create(
-                {
-                    "message_type": "notification",
-                    "subtype_id": self.env.ref("mail.mt_comment").id,
-                    "date": datetime.now(),
-                    "body": "<p>Only %s unused Bitcoin addresses are left. "
-                    "Please add new addresses.</p>" % unused_address_count,
-                    "partner_ids": needaction_partner_ids,
-                    "needaction": True,
-                }
-            )
         return
 
     @api.constrains("name")


### PR DESCRIPTION
This is an attempt to re-enable notification about low payment address count.