### PR TITLE
No customer ref overwrite

### DIFF
--- a/payment_bitcoin/models/account_payment.py
+++ b/payment_bitcoin/models/account_payment.py
@@ -9,15 +9,3 @@ class AccountPaymentMethod(models.Model):
         res = super()._get_payment_method_information()
         res["bitcoin"] = {"mode": "unique", "domain": [("type", "=", "bank")]}
         return res
-
-
-class AccountMove(models.Model):
-    _inherit = "account.move"
-
-    def _post(self, soft=True):
-        res = super()._post(soft=soft)
-        for move in self:
-            order = move.invoice_line_ids.mapped("sale_line_ids.order_id")
-            if order:
-                move.ref = ", ".join(order.mapped("name"))
-        return res

--- a/payment_bitcoin/models/bitcoin.py
+++ b/payment_bitcoin/models/bitcoin.py
@@ -229,7 +229,7 @@ class BitcoinAddress(models.Model):
             amount_received = self.convert_num_to_standard(address_info["received"])
             if valid_rate and address_info["received"] >= valid_rate:
                 open_invoice_objs = None
-                if bit_add_obj.order_id and bit_add_obj.order_id.state == "cancel":
+                if bit_add_obj.order_id and bit_add_obj.order_id.state != "cancel":
                     if bit_add_obj.order_id.state not in ("done", "sale"):
                         bit_add_obj.order_id.action_confirm()
 


### PR DESCRIPTION
Preventing customer reference on invoice to be overwritten when confirming the invoice by the name of the sale order